### PR TITLE
implement ability to ignore missing services without error

### DIFF
--- a/whitelabel/core.py
+++ b/whitelabel/core.py
@@ -58,6 +58,8 @@ this.log_bucket = os.environ['LOG_BUCKET']+".s3.amazonaws.com"
 
 this.dry_run = 'DRY_RUN' in os.environ and os.environ['DRY_RUN']
 
+this.ignore_missing_services = 'IGNORE_MISSING_SERVICES' in os.environ and os.environ['IGNORE_MISSING_SERVICES']
+
 
 # This will be set to DNS name, which we will use as CNAME
 # destination 
@@ -206,6 +208,17 @@ def discover_clients(defs):
         this.clients[client['domain'].lower()] = {}
 
         for subdomain in client['subdomains']:
+
+            if subdomain['service'] not in this.services and this.ignore_missing_services:
+                print("skipping %s.%s%s because service %s not supported by infrastructure " % (
+                    subdomain['name'],
+                    client['domain'],
+                    this.sandbox_dot,
+                    subdomain['service']
+                ))
+
+                continue
+
 
             this.clients[client['domain'].lower()][subdomain['name'].lower()] = subdomain
 


### PR DESCRIPTION
This adds support for environment variable:

``` ini
IGNORE_MISSING_SERVICES=yes
```

when set, services that are requested in `client-config` and are not defined in `service-config` will be ignored. 

Normally that causes error.

## Testing
no need for manual testing, but this feature is automatically used by https://github.com/medsleuthinc/infrastructure/pull/641, so if that PR works, this can also be merged.